### PR TITLE
Allow hill cost and hill cutoff in way context

### DIFF
--- a/brouter-core/src/main/java/btools/router/KinematicPath.java
+++ b/brouter-core/src/main/java/btools/router/KinematicPath.java
@@ -248,12 +248,12 @@ final class KinematicPath extends OsmPath {
 
 
   @Override
-  public int elevationCorrection(RoutingContext rc) {
+  public int elevationCorrection() {
     return 0;
   }
 
   @Override
-  public boolean definitlyWorseThan(OsmPath path, RoutingContext rc) {
+  public boolean definitlyWorseThan(OsmPath path) {
     KinematicPath p = (KinematicPath) path;
 
     int c = p.cost;

--- a/brouter-core/src/main/java/btools/router/OsmPath.java
+++ b/brouter-core/src/main/java/btools/router/OsmPath.java
@@ -409,9 +409,9 @@ abstract class OsmPath implements OsmLinkHolder {
   protected void computeKinematic(RoutingContext rc, double dist, double delta_h, boolean detailMode) {
   }
 
-  public abstract int elevationCorrection(RoutingContext rc);
+  public abstract int elevationCorrection();
 
-  public abstract boolean definitlyWorseThan(OsmPath p, RoutingContext rc);
+  public abstract boolean definitlyWorseThan(OsmPath p);
 
   public OsmNode getSourceNode() {
     return sourceNode;

--- a/brouter-core/src/main/java/btools/router/RoutingContext.java
+++ b/brouter-core/src/main/java/btools/router/RoutingContext.java
@@ -52,10 +52,6 @@ public final class RoutingContext {
 
   public int memoryclass = 64;
 
-  public int downhillcostdiv;
-  public int downhillcutoff;
-  public int uphillcostdiv;
-  public int uphillcutoff;
   public boolean carMode;
   public boolean bikeMode;
   public boolean footMode;
@@ -121,12 +117,6 @@ public final class RoutingContext {
 
     setModel(expctxGlobal._modelClass);
 
-    downhillcostdiv = (int) expctxGlobal.getVariableValue("downhillcost", 0.f);
-    downhillcutoff = (int) (expctxGlobal.getVariableValue("downhillcutoff", 0.f) * 10000);
-    uphillcostdiv = (int) expctxGlobal.getVariableValue("uphillcost", 0.f);
-    uphillcutoff = (int) (expctxGlobal.getVariableValue("uphillcutoff", 0.f) * 10000);
-    if (downhillcostdiv != 0) downhillcostdiv = 1000000 / downhillcostdiv;
-    if (uphillcostdiv != 0) uphillcostdiv = 1000000 / uphillcostdiv;
     carMode = 0.f != expctxGlobal.getVariableValue("validForCars", 0.f);
     bikeMode = 0.f != expctxGlobal.getVariableValue("validForBikes", 0.f);
     footMode = 0.f != expctxGlobal.getVariableValue("validForFoot", 0.f);

--- a/brouter-core/src/main/java/btools/router/RoutingEngine.java
+++ b/brouter-core/src/main/java/btools/router/RoutingEngine.java
@@ -790,7 +790,7 @@ public class RoutingEngine extends Thread {
               if (parentcost < firstMatchCost) firstMatchCost = parentcost;
 
               int costEstimate = path.cost
-                + path.elevationCorrection(routingContext)
+                + path.elevationCorrection()
                 + (costCuttingTrack.cost - pe.cost);
               if (costEstimate <= maxTotalCost) {
                 matchPath = OsmPathElement.create(path, routingContext.countTraffic);
@@ -922,7 +922,7 @@ public class RoutingEngine extends Thread {
               OsmLinkHolder dominator = link.getFirstLinkHolder(currentNode);
               while (!trafficSim && dominator != null) {
                 OsmPath dp = (OsmPath) dominator;
-                if (dp.airdistance != -1 && bestPath.definitlyWorseThan(dp, routingContext)) {
+                if (dp.airdistance != -1 && bestPath.definitlyWorseThan(dp)) {
                   break;
                 }
                 dominator = dominator.getNextForLink();

--- a/brouter-expressions/src/main/java/btools/expressions/BExpressionContextWay.java
+++ b/brouter-expressions/src/main/java/btools/expressions/BExpressionContextWay.java
@@ -12,7 +12,7 @@ public final class BExpressionContextWay extends BExpressionContext implements T
   private boolean decodeForbidden = true;
 
   private static String[] buildInVariables =
-    {"costfactor", "turncost", "uphillcostfactor", "downhillcostfactor", "initialcost", "nodeaccessgranted", "initialclassifier", "trafficsourcedensity", "istrafficbackbone", "priorityclassifier", "classifiermask", "maxspeed"};
+    {"costfactor", "turncost", "uphillcostfactor", "downhillcostfactor", "initialcost", "nodeaccessgranted", "initialclassifier", "trafficsourcedensity", "istrafficbackbone", "priorityclassifier", "classifiermask", "maxspeed", "uphillcost", "downhillcost", "uphillcutoff", "downhillcutoff"};
 
   protected String[] getBuildInVariableNames() {
     return buildInVariables;
@@ -64,6 +64,22 @@ public final class BExpressionContextWay extends BExpressionContext implements T
 
   public float getMaxspeed() {
     return getBuildInVariable(11);
+  }
+
+  public float getUphillcost() {
+    return getBuildInVariable(12);
+  }
+
+  public float getDownhillcost() {
+    return getBuildInVariable(13);
+  }
+
+  public float getUphillcutoff() {
+    return getBuildInVariable(14);
+  }
+
+  public float getDownhillcutoff() {
+    return getBuildInVariable(15);
   }
 
   public BExpressionContextWay(BExpressionMetaData meta) {

--- a/docs/developers/profile_developers_guide.md
+++ b/docs/developers/profile_developers_guide.md
@@ -72,12 +72,8 @@ Some variable names are pre-defined and accessed by the routing engine:
 
 - for the global section these are:
 
-  - 7 elevation configuration parameters:
+  - 3 elevation configuration parameters:
 
-    - `downhillcost`
-    - `downhillcutoff`
-    - `uphillcost`
-    - `uphillcutoff`
     - `elevationpenaltybuffer`
     - `elevationmaxbuffer`
     - `elevationbufferreduce`
@@ -119,6 +115,10 @@ Some variable names are pre-defined and accessed by the routing engine:
   - `costfactor`
   - `uphillcostfactor`
   - `downhillcostfactor`
+  - `uphillcost`
+  - `uphillcutoff`
+  - `downhillcost`
+  - `downhillcutoff`
   - `nodeaccessgranted`
   - `initialclassifier`
   - `priorityclassifier`

--- a/docs/developers/profile_developers_guide.md
+++ b/docs/developers/profile_developers_guide.md
@@ -72,8 +72,12 @@ Some variable names are pre-defined and accessed by the routing engine:
 
 - for the global section these are:
 
-  - 3 elevation configuration parameters:
+  - 7 elevation configuration parameters:
 
+    - `downhillcost`
+    - `downhillcutoff`
+    - `uphillcost`
+    - `uphillcutoff`
     - `elevationpenaltybuffer`
     - `elevationmaxbuffer`
     - `elevationbufferreduce`
@@ -115,10 +119,6 @@ Some variable names are pre-defined and accessed by the routing engine:
   - `costfactor`
   - `uphillcostfactor`
   - `downhillcostfactor`
-  - `uphillcost`
-  - `uphillcutoff`
-  - `downhillcost`
-  - `downhillcutoff`
   - `nodeaccessgranted`
   - `initialclassifier`
   - `priorityclassifier`


### PR DESCRIPTION
This removes the limitation that `downhillcutoff` and `uphillcutoff` as well as `downhillcost` and `uphillcost` cannot be used in the way context.